### PR TITLE
Improve quickstart.sh script

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -14,7 +14,6 @@ docker pull redis
 
 git clone git@github.com:kodokojo/commons-tests.git
 git clone git@github.com:kodokojo/commons.git
-git clone git@github.com:kodokojo/kodokojo.git
 git clone git@github.com:kodokojo/kodokojo-ui.git
 git clone git@github.com:kodokojo/kodokojo-haproxy-marathon.git
 
@@ -36,6 +35,4 @@ chmod +x build.sh
 ./build.sh
 popd
 
-pushd kodokojo
 mvn -P docker clean install verify
-popd


### PR DESCRIPTION
Allow execution on `quickstart.sh` script and do not clone `kodokojo` repository since we are already located inside this project when executing the script.
