### PR TITLE
kod-116 Add SesEmailSender

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,25 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ses</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-core</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-annotations</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>javax.mail</artifactId>
         <version>1.5.5</version>

--- a/src/main/java/io/kodokojo/Launcher.java
+++ b/src/main/java/io/kodokojo/Launcher.java
@@ -41,7 +41,6 @@ public class Launcher {
 
         INJECTOR = Guice.createInjector(new PropertyModule(args),
                 new SecurityModule(),
-                new EmailSenderModule(),
                 new RedisModule(),
                 new ServiceModule(),
                 new ActorModule(),

--- a/src/main/java/io/kodokojo/config/module/AwsModule.java
+++ b/src/main/java/io/kodokojo/config/module/AwsModule.java
@@ -1,17 +1,17 @@
 /**
  * Kodo Kojo - Software factory done right
  * Copyright © 2016 Kodo Kojo (infos@kodokojo.io)
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -26,7 +26,12 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.kodokojo.config.ApplicationConfig;
 import io.kodokojo.config.AwsConfig;
+import io.kodokojo.config.EmailConfig;
+import io.kodokojo.service.EmailSender;
+import io.kodokojo.service.NoopEmailSender;
+import io.kodokojo.service.SmtpEmailSender;
 import io.kodokojo.service.aws.Route53DnsManager;
+import io.kodokojo.service.aws.SesEmailSender;
 import io.kodokojo.service.dns.DnsManager;
 import io.kodokojo.service.dns.NoOpDnsManager;
 import org.apache.commons.lang.StringUtils;
@@ -58,6 +63,27 @@ public class AwsModule extends AbstractModule {
         } else {
             LOGGER.info("Using Route53DnsManager as DnsManger implementation");
             return new Route53DnsManager(applicationConfig.domain(), Region.getRegion(Regions.fromName(awsConfig.region())));
+        }
+    }
+
+    @Provides
+    @Singleton
+    EmailSender provideEmailSender(AwsConfig awsConfig, EmailConfig emailConfig) {
+        if (StringUtils.isBlank(emailConfig.smtpHost())) {
+            AWSCredentials credentials = null;
+            try {
+                DefaultAWSCredentialsProviderChain defaultAWSCredentialsProviderChain = new DefaultAWSCredentialsProviderChain();
+                credentials = defaultAWSCredentialsProviderChain.getCredentials();
+            } catch (RuntimeException e) {
+                LOGGER.warn("Unable to retrieve AWS credentials.");
+            }
+            if (credentials == null) {
+                return new NoopEmailSender();
+            } else {
+                return new SesEmailSender(emailConfig.smtpFrom(), Region.getRegion(Regions.fromName(awsConfig.region())));
+            }
+        } else {
+            return new SmtpEmailSender(emailConfig.smtpHost(), emailConfig.smtpPort(), emailConfig.smtpUsername(), emailConfig.smtpPassword(), emailConfig.smtpFrom());
         }
     }
 }

--- a/src/main/java/io/kodokojo/service/aws/SesEmailSender.java
+++ b/src/main/java/io/kodokojo/service/aws/SesEmailSender.java
@@ -1,0 +1,63 @@
+package io.kodokojo.service.aws;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.services.simpleemail.model.*;
+import io.kodokojo.service.EmailSender;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public class SesEmailSender implements EmailSender {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SesEmailSender.class);
+    
+    private final String from;
+
+    private final Region region;
+
+    public SesEmailSender(String from, Region region) {
+        if (isBlank(from)) {
+            throw new IllegalArgumentException("from must be defined.");
+        }
+        if (region == null) {
+            throw new IllegalArgumentException("region must be defined.");
+        }
+        this.from = from;
+        this.region = region;
+    }
+
+    @Override
+    public void send(List<String> to, List<String> cc, List<String> ci, String object, String content, boolean htmlContent) {
+        if (CollectionUtils.isEmpty(to)) {
+            throw new IllegalArgumentException("to must be defined.");
+        }
+        if (isBlank(content)) {
+            throw new IllegalArgumentException("content must be defined.");
+        }
+        Destination destination = new Destination().withToAddresses(to).withBccAddresses(ci).withCcAddresses(cc);
+        Content subject = new Content().withData(object);
+        Content bodyContent = new Content().withData(content);
+        Body body;
+        if (htmlContent) {
+            body = new Body().withHtml(bodyContent);
+        } else {
+            body = new Body().withText(bodyContent);
+        }
+        Message message = new Message().withSubject(subject).withBody(body);
+        SendEmailRequest request = new SendEmailRequest().withSource(from).withDestination(destination).withMessage(message);
+        try {
+            AmazonSimpleEmailServiceClient client = new AmazonSimpleEmailServiceClient();
+            client.setRegion(region);
+            client.sendEmail(request);
+        } catch (Exception e) {
+            LOGGER.error("Unable to send email to {} with subject '{}'", StringUtils.join(to, ","), subject, e);
+        }
+    }
+
+}


### PR DESCRIPTION
Instead of using SMTP configuration, this PR allow us to use SES API which use IAM roles to allow an EC2 instance to send Email.

Must be tested on EC2 env.
