### PR TITLE
fix(DOCKER_CERT_OPT): fix script when DOCKER_CERT_OPT not there

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,12 @@ if [ ! -x "$DOCKER_BIN_PATH" ]; then
   exit 1
 fi
 
-docker run -it --rm -v $DOCKER_CERT_PATH:$DOCKER_CERT_PATH -v /tmp/kodokojo/.m2:/root/.m2 -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven -e "DOCKER_HOST=$DOCKER_HOST" -e "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" -v ${DOCKER_BIN_PATH}:/usr/bin/docker maven:3-jdk-8 mvn -P docker install verify
+DOCKER_CERT_OPT=""
+if [ x "$DOCKER_CERT_PATH" ]; then
+  DOCKER_CERT_OPT="-v $DOCKER_CERT_PATH:$DOCKER_CERT_PATH"
+fi
+
+docker run -it --rm $DOCKER_CERT_OPT -v /tmp/kodokojo/.m2:/root/.m2 -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven -e "DOCKER_HOST=$DOCKER_HOST" -e "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" -v ${DOCKER_BIN_PATH}:/usr/bin/docker maven:3-jdk-8 mvn -P docker install verify
 rc=$?
 if [[ $rc != 0 ]]; then
   exit $rc

--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ if [ ! -x "$DOCKER_BIN_PATH" ]; then
 fi
 
 DOCKER_CERT_OPT=""
-if [ x "$DOCKER_CERT_PATH" ]; then
+if [ -x "$DOCKER_CERT_PATH" ]; then
   DOCKER_CERT_OPT="-v $DOCKER_CERT_PATH:$DOCKER_CERT_PATH"
 fi
 


### PR DESCRIPTION
When there is no DOCKER_CERT_OPT, we get an error:

docker: Error response from daemon: Invalid volume spec ":": Invalid
volume specification: ':'.

see #16