### PR TITLE
Add Parameter to ignore Marathon Contraint location

### DIFF
--- a/src/main/java/io/kodokojo/config/MarathonConfig.java
+++ b/src/main/java/io/kodokojo/config/MarathonConfig.java
@@ -25,4 +25,7 @@ public interface MarathonConfig extends PropertyConfig {
     @Key("marathon.url")
     String url();
 
+    @Key(value = "marathon.ignore.constraint", defaultValue = "FALSE")
+    Boolean ignoreContraint();
+
 }

--- a/src/main/java/io/kodokojo/config/module/MarathonModule.java
+++ b/src/main/java/io/kodokojo/config/module/MarathonModule.java
@@ -48,7 +48,7 @@ public class MarathonModule extends AbstractModule {
     @Singleton
     BrickManager provideBrickManager(MarathonConfig marathonConfig, BrickConfigurerProvider brickConfigurerProvider, ApplicationConfig applicationConfig, ProjectStore projectStore, BrickUrlFactory brickUrlFactory) {
         MarathonServiceLocator marathonServiceLocator = new MarathonServiceLocator(marathonConfig.url());
-        return new MarathonBrickManager(marathonConfig.url(), marathonServiceLocator, brickConfigurerProvider, projectStore, applicationConfig.domain(), brickUrlFactory);
+        return new MarathonBrickManager(marathonConfig.url(), marathonServiceLocator, brickConfigurerProvider, projectStore, !marathonConfig.ignoreContraint(), applicationConfig.domain(), brickUrlFactory);
     }
 
     @Provides

--- a/src/test/resources/docker/full/docker-compose.yml
+++ b/src/test/resources/docker/full/docker-compose.yml
@@ -6,7 +6,7 @@ kodokojo-ui:
     - kodokojo
 kodokojo:
   image: kodokojo/kodokojo
-  entrypoint: java -Dlogback.configurationFile=/debug-logback.xml -Djavax.net.ssl.keyStore=/keystore.jks -Djavax.net.ssl.keyStorePassword=password -Dsecurity.ssl.rootCa.ks.alias=rootcafake -Dsecurity.ssl.rootCa.ks.password=password -Dapplication.dns.domain=kodokojo.dev -Dmarathon.url=http://192.168.99.100:8080 -Dlb.host=192.168.99.100 -jar /project/kodokojo.jar
+  entrypoint: java -Dlogback.configurationFile=/debug-logback.xml -Djavax.net.ssl.keyStore=/keystore.jks -Djavax.net.ssl.keyStorePassword=password -Dsecurity.ssl.rootCa.ks.alias=rootcafake -Dsecurity.ssl.rootCa.ks.password=password -Dapplication.dns.domain=kodokojo.dev -Dmarathon.url=http://192.168.99.100:8080 -Dmarathon.ignore.constraint=TRUE -Dlb.host=192.168.99.100 -jar /project/kodokojo.jar
   ports:
     - 9080:80
   volumes:


### PR DESCRIPTION
When trying to run kodo Kojo over quickestart, we don't need to use all
Marathon constraints.
We add 'marathon.ignore.constraint' parameter which allow to ignore thos
contraint when it defined to 'true'.
This paramter is defined to false by default.