### PR TITLE
fix(‘target/docker’: Permission denied)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ if [ -x "$DOCKER_CERT_PATH" ]; then
   DOCKER_CERT_OPT="-v $DOCKER_CERT_PATH:$DOCKER_CERT_PATH"
 fi
 
-docker run -it --rm $DOCKER_CERT_OPT -v /tmp/kodokojo/.m2:/root/.m2 -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven -e "DOCKER_HOST=$DOCKER_HOST" -e "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" -v ${DOCKER_BIN_PATH}:/usr/bin/docker maven:3-jdk-8 mvn clean install verify
+docker run -it --rm $DOCKER_CERT_OPT -v /tmp/kodokojo/.m2:/root/.m2 -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven -e "DOCKER_HOST=$DOCKER_HOST" -e "DOCKER_CERT_PATH=$DOCKER_CERT_PATH" --env "MAVEN_USER=$USER"  -v ${DOCKER_BIN_PATH}:/usr/bin/docker maven:3-jdk-8 /bin/bash -c 'mvn clean install verify; useradd -p toto $MAVEN_USER; chown -R $MAVEN_USER:$MAVEN_USER ./target'
 rc=$?
 if [[ $rc != 0 ]]; then
   exit $rc


### PR DESCRIPTION
This is a proposal of fix for the issue #26.
- add an environment variable MAVEN_USER with the user of the terminal
- add this user in the container
- add chown command with $MAVEN_USER:$MAVEN_USER to the target directory