### PR TITLE
kod-150 - Use root to write in gluster fs

### DIFF
--- a/src/main/resources/marathon/gitlab.json.vm
+++ b/src/main/resources/marathon/gitlab.json.vm
@@ -39,6 +39,10 @@
         {
           "key": "label",
           "value": "component=gitlab"
+        },
+        {
+          "key": "user",
+          "value": "root"
         }
       ]
     },

--- a/src/main/resources/marathon/jenkins.json.vm
+++ b/src/main/resources/marathon/jenkins.json.vm
@@ -36,6 +36,10 @@
         {
           "key": "label",
           "value": "component=jenkins"
+        },
+        {
+          "key": "user",
+          "value": "root"
         }
       ]
     },

--- a/src/main/resources/marathon/nexus.json.vm
+++ b/src/main/resources/marathon/nexus.json.vm
@@ -37,6 +37,10 @@
         {
           "key": "label",
           "value": "component=nexus"
+        },
+        {
+          "key": "user",
+          "value": "root"
         }
       ]
     },


### PR DESCRIPTION
Since volume directory presistence is created by the Docker deamon, we
need to run as root inside container to allow our brick to weite in
there persistence directory share with host (or gluster in our case).